### PR TITLE
Fixes ribbon link on speakers modal

### DIFF
--- a/_includes/speakers-modals.html
+++ b/_includes/speakers-modals.html
@@ -37,7 +37,7 @@
 									{% if speaker.ribbon != null %}
 									<div class="modal-ribbon-wrapper">
 			                            {% for ribbon in speaker.ribbon %}
-			                               <a class="modal-ribbon" href="ribbon["url"]" target="_blank">{{ ribbon["title"] }}</a>   
+			                               <a class="modal-ribbon" href="{{ ribbon["url"] }}" target="_blank">{{ ribbon["title"] }}</a>   
 			                            {% endfor %}
 			                        </div>
 			                        {% endif %}


### PR DESCRIPTION
Just added the necessary  "{{" and "}}".
