### PR TITLE
Added GDG Dusseldorf DevFest 2014 URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Going to use template? Go on! The only thing we ask - let us know at [*lviv@gdg.
 * [DevFest in Baroda](devfest.gdgbaroda.com)
 * [GDG Hi Pic (France)](http://maximemularz.github.io/zeppelin/)
 * [GDG DevFest Córdoba 2014](http://gdgcordoba.github.io/zeppelin/)
+* [GDG DevFest Düsseldorf 2014](http://www.gdg-dus.de/DevFest2014/)
 
 ### Contributors
 * Design and web development: [Oleh Zasadnyy](https://github.com/ozasadnyy)


### PR DESCRIPTION
Thank you for this great template!
You saved us a lot of development time for our [DevFest Düsseldorf 2014](http://www.gdg-dus.de/DevFest2014/) site!
