### PR TITLE
Auto Directions in Logistics page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -215,6 +215,7 @@ findWayTransit: "TRANSIT"
 findWayFindFlight: "Find Flight"
 logisticsMapCenterCoordinates: "49.056728, 3.117289"
 logisticsMapMobileCenterCoordinates: "48.335365, 23.711648"
+logisticsMapAutoDirections: true
 
 # Logistics Direction Details Block
 directionDetailsImage: "direction-details.jpg"

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -1,3 +1,5 @@
+---
+---
 (function($) {
     $(document).ready(function() {
         $(window).load(function() {
@@ -570,6 +572,15 @@
                 smoothZoom(5);
                 $('#find-way h3').removeClass('fadeOutDown').addClass('fadeInUp');
             });
+            
+            {% if site.logisticsMapAutoDirections %}
+            if (googleMaps == 'logistics' && navigator.geolocation) {
+                navigator.geolocation.getCurrentPosition(function(position) {
+                    origin = new google.maps.LatLng(position.coords.latitude, position.coords.longitude);
+                    calcRoute(origin, 'DRIVING');
+                });
+            }
+            {% endif %}
         }
 
         google.maps.event.addDomListener(window, 'load', initialize);


### PR DESCRIPTION
Added a configuration for Jekyll to enable/disable auto directions in Logistics page. 

I have seen several people using the web site and no once noticed **"my location"** button in the Logistics page. So I decided to get their location immediately when they open Logistics page.

And then I thought it may be a config after all. 

I am an Android developer. So I am a newbie to this. 
So please guide me. :smile: 

With this code when I change `scripts.min.js` to `scripts.js` it works. But it cannot be minified because minifier thinks that `{%` illegal. What should I do? Thank you. 
