### PR TITLE
Fix in the rockstar count.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -95,7 +95,7 @@ layout: compress
                 rockstarSpeakers.sort(function() {return 0.5 - Math.random()});
                 if(rockstarSpeakers.length > 0) {
                     var animationDelay = 1500,
-                        count = {{ site.rockstarSpeakersCount }},
+                        count = Math.min({{ site.rockstarSpeakersCount }}, rockstarSpeakers.length),
                         colWidth = 12/count;
                     for(i=0; i<count; i++) {
                         var clearfix = '<div class="clearfix visible-xs"></div>';


### PR DESCRIPTION
I had a problem with rockstar speakers that I couldn't solve for hours. 
The problem was rockstar count was 4 in the config but I provided 3 rockstars in speakers.yml

The problem can be solved by changing the config from 4 to 3 but it can drive people crazy. Because the website becomes broken and doesn't open.

This will ensure the count is always the right count and prevent website braking.