### PR TITLE
Next Button bug fix. 

### DIFF
--- a/_includes/speakers-list.html
+++ b/_includes/speakers-list.html
@@ -44,7 +44,7 @@
                                     <p class="position">{{ speaker.company }}</p>
                                 {% endif %}
                             </ul>
-                            <a href="#" class="slider-next-item {% if sessionsNumber == 1 %}hidden{% endif %}">Next</a>
+                            <a href="#" class="slider-next-item {% if sessionsNumber < 2 %}hidden{% endif %}">Next</a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
I enabled `showSessions` in config. 
The Speakers page is updated but it was showing Next button on empty descriptions. It was because some of the sessions of some speakers are not ready yet. It is now fixed. 