### PR TITLE
Description support in service sessions.

### DIFF
--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -62,6 +62,9 @@
                                     <div class="color-line"></div>
                                     <div class="slot-content">
                                         <h5 class="slot-title" itemprop="name">{{ session.title }}</h5>
+                                        {% if session.description != null %}
+                                        <p class="theme-description"><br>{{ session.description }}</p>
+                                        {% endif %}
                                     </div>
                                 </div>
                                 {% endif %}


### PR DESCRIPTION
The service slots looks really empty. They can have description now. If they don't have a description, they look the same as before.