### PR TITLE
Manifest is added for web app configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,7 @@ exclude: ['/automation/', 'README.md', 'LICENSE.txt', 'CNAME']
 
 
 # Site Settings
+short_title: "DevFest14"
 title: "GDG DevFest Season 2014"
 email: "devfest@gdg.org.ua"
 description: "GDG DevFest is a set of events all around the world"

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -43,6 +43,8 @@
     
     <link href="{{ "/css/main.css" | prepend: site.baseurl }}" rel="stylesheet"> 
 
+    <link rel="manifest" href="{{ site.baseurl }}/manifest.json">
+
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,20 @@
+---
+layout: null
+---
+{
+  "short_name": "{{ site.short_title }}",
+  "name": "{{ site.title }}",
+  "icons": [
+    {
+      "src": "{{ site.baseurl }}/img/favicons/favicon-96x96.png",
+      "sizes": "96x96",
+      "type": "image/png"
+    },
+    {
+      "src": "{{ site.baseurl  }}/img/favicons/apple-touch-icon-144x144.png",
+      "sizes": "144x144",
+      "type": "image/png"
+    }
+  ],
+  "display": "standalone"
+}


### PR DESCRIPTION
With this manifest 2 things occur when you press "Add to homescreen" button on Android

- short_name is used as an app name on the homescreen. 
- with standalone tag, the app feels like a native app without google chromes other buttons like search, history, etc.