### PR TITLE
Install banner

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -51,17 +51,4 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
       <![endif]-->
-    <script>
-        window.addEventListener('load', function() {
-          navigator.serviceWorker.register('{{ site.baseurl }}/service-worker.js', {scope: '{{ site.baseurl }}/'})
-            .then(function(r) {
-              console.log('registered service worker');
-            })
-            .catch(function(whut) {
-              console.error('uh oh... ');
-              console.error(whut);
-            });
-        });
-    </script>
-    
   </head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -51,4 +51,17 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
       <![endif]-->
+    <script>
+        window.addEventListener('load', function() {
+          navigator.serviceWorker.register('{{ site.baseurl }}/service-worker.js', {scope: '{{ site.baseurl }}/'})
+            .then(function(r) {
+              console.log('registered service worker');
+            })
+            .catch(function(whut) {
+              console.error('uh oh... ');
+              console.error(whut);
+            });
+        });
+    </script>
+    
   </head>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -131,6 +131,9 @@ layout: compress
         {% endif %} 
     </script>
     <script src="{{ "/js/scripts.min.js" | prepend: site.baseurl }}"></script>
+    <script>
+        navigator.serviceWorker.register('{{ site.baseurl }}/service-worker.js', {scope: '{{ site.baseurl }}/'});
+    </script>
     {% if page.permalink == '/schedule/' %}
         <script type="text/javascript">
             $(document).ready(function () {

--- a/manifest.json
+++ b/manifest.json
@@ -8,13 +8,16 @@ layout: null
     {
       "src": "{{ site.baseurl }}/img/favicons/favicon-96x96.png",
       "sizes": "96x96",
-      "type": "image/png"
+      "type": "image/png",
+      "density": "2.0"
     },
     {
       "src": "{{ site.baseurl  }}/img/favicons/apple-touch-icon-144x144.png",
       "sizes": "144x144",
-      "type": "image/png"
+      "type": "image/png",
+      "density": "3.0"
     }
   ],
-  "display": "standalone"
+  "display": "standalone",
+  "start_url": "{{ site.baseurl }}/index.html"
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,2 @@
+// Empty service worker for App Install banners to work. 
+// Can be implemented to have offline and sync support. 


### PR DESCRIPTION
Install banner feature is added as can be seen on the screenshot on #67 

More info about this can be found on
http://updates.html5rocks.com/2015/03/increasing-engagement-with-app-install-banners-in-chrome-for-android

To test this:
Install Chrome Beta for Android and have this flag enabled chrome://flags/#bypass-app-banner-engagement-checks 