### PR TITLE
Add PTMConf 2018

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Going to use template? Go on! The only thing we ask - let us know at [*lviv@gdg.
 | [Mobile Era 2016](http://mobileera.rocks/) | [GDG Francisco Beltrão](http://gdg-fb.github.io) | [Women Techmakers Istanbul 2016](http://2016.wtmistanbul.com) |
 | [Droidcon Paris 2015](http://droidcon.fr) | [Android Makers Paris 2017](http://androidmakers.fr) | [Heidelberger Symposium 2017](https://heidelberger-symposium.de/) |
 | [DevFest Foumban website](http://devfestfoumban.org) | [NorthSec 2018](https://nsec.io/) | [SwiftFest 2018](http://swiftfest.io) |
+|[PTMConf 2018](https://ptmconf.com/)|||
 
 
 ### Contributors


### PR DESCRIPTION
Add Porto Testers Meetup Conference 2018.
https://ptmconf.com/

/cc @ozasadnyy @zasadnyy @tasomaniac 