### PR TITLE
Update to include RootedCON

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Going to use template? Go on! The only thing we ask - let us know at [*lviv@gdg.
 | [Mobile Era 2016](http://mobileera.rocks/) | [GDG Francisco Beltrão](http://gdg-fb.github.io) | [Women Techmakers Istanbul 2016](http://2016.wtmistanbul.com) |
 | [Droidcon Paris 2015](http://droidcon.fr) | [Android Makers Paris 2017](http://androidmakers.fr) | [Heidelberger Symposium 2017](https://heidelberger-symposium.de/) |
 | [DevFest Foumban website](http://devfestfoumban.org) | [NorthSec 2018](https://nsec.io/) | [SwiftFest 2018](http://swiftfest.io) |
-|[LASCAR Workshop](http://lascar.sda.tech/)| [Core C++ 2019](https://corecpp.org/) ||
+|[LASCAR Workshop](http://lascar.sda.tech/)| [Core C++ 2019](https://corecpp.org/) | [RootedCON](https://www.rootedcon.com)|
 
 
 ### Contributors


### PR DESCRIPTION
Adding RootedCON Security Congress (Spain) to the list of websites using zeppelin